### PR TITLE
Updated the build.sh to add the shebang

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,2 @@
+#!/bin/env bash
 gcc -lSDL3 -lm main.c SDL3_ttf/lib/libSDL3_ttf.a -lharfbuzz -lfreetype -o bytepusher


### PR DESCRIPTION
Adds shebang since otherwise it would cause an errno of `ENOEXEC`. Which most shell respond with trying to run the script with themself.

This simply guarantees behavior
